### PR TITLE
use alias field to correctly read container IDs

### DIFF
--- a/stats/aggregated_stats.go
+++ b/stats/aggregated_stats.go
@@ -13,6 +13,7 @@ type AggregatedStats []AggregatedStat
 type AggregatedStat struct {
 	Id           string `json:"id,omitempty"`
 	ResourceType string `json:"resourceType,omitempty"`
+	MemLimit     uint64 `json:"memLimit,omitempty"`
 	*info.ContainerStats
 }
 
@@ -62,7 +63,7 @@ func convertCadvisorStatToAggregatedStat(id string, aliases []string, name strin
 			}
 		}
 	}
-	return AggregatedStat{id, resourceType, stat}
+	return AggregatedStat{id, resourceType, memLimit, stat}
 }
 
 func writeAggregatedStats(id string, containerIds map[string]string, resourceType string, infos []info.ContainerInfo, memLimit uint64, writer io.Writer) error {

--- a/stats/aggregated_stats.go
+++ b/stats/aggregated_stats.go
@@ -24,7 +24,7 @@ func convertToAggregatedStats(id string, containerIds map[string]string, resourc
 		aggregatedStats := []AggregatedStat{}
 		for _, stat := range stats {
 			if len(stat.Stats) > i {
-				statPoint := convertCadvisorStatToAggregatedStat(id, stat.Name, containerIds, resourceType, memLimit, stat.Stats[i])
+				statPoint := convertCadvisorStatToAggregatedStat(id, stat.Aliases, stat.Name, containerIds, resourceType, memLimit, stat.Stats[i])
 				if statPoint.Id == "" {
 					continue
 				}
@@ -36,7 +36,7 @@ func convertToAggregatedStats(id string, containerIds map[string]string, resourc
 	return totalAggregatedStats
 }
 
-func convertCadvisorStatToAggregatedStat(id string, name string, containerIds map[string]string, resourceType string, memLimit uint64, stat *info.ContainerStats) AggregatedStat {
+func convertCadvisorStatToAggregatedStat(id string, aliases []string, name string, containerIds map[string]string, resourceType string, memLimit uint64, stat *info.ContainerStats) AggregatedStat {
 	if resourceType == "container" {
 		if id == "" {
 			id = name
@@ -49,7 +49,17 @@ func convertCadvisorStatToAggregatedStat(id string, name string, containerIds ma
 		if idVal, ok := containerIds[id]; ok {
 			id = idVal
 		} else {
-			return AggregatedStat{}
+			found := false
+			for _, alias := range aliases {
+				if idVal, ok := containerIds[alias]; ok {
+					id = idVal
+					found = true
+					break
+				}
+			}
+			if !found {
+				return AggregatedStat{}
+			}
 		}
 	}
 	return AggregatedStat{id, resourceType, stat}


### PR DESCRIPTION
@cjellick @cloudnautique @vincent99 

We used to rely on the container ID returned by cadvisor to match containerIDs to cattle instance resource Ids.

Cadvisor returned Ids were not consistent across OSes. 

For eg, in Ubuntu, it is of the format

``` /docker/$ID ```

where ID is the docker generated ID

in CentOS, it is of the format

`/system.slice/docker-$ID.scope`

Due to this, the matching on CentOS failed.

This PR addresses this above issue, by matching with a different field called as alias. Alias has been found to have the ID in the correct format across different OSes.

The second commit brings back the memLimit field, which was lost when we upgraded to cadvisor v0.12.0.