### PR TITLE
tune down red herring log statement to debug

### DIFF
--- a/events/send_to_rancher_handler.go
+++ b/events/send_to_rancher_handler.go
@@ -23,7 +23,7 @@ func (h *SendToRancherHandler) Handle(event *docker.APIEvents) error {
 	// Note: event.ID == container's ID
 	lock := locks.Lock(event.Status + event.ID)
 	if lock == nil {
-		log.Warnf("Container locked. Can't run SendToRancherHandler. Event: [%s], ID: [%s]", event.Status, event.ID)
+		log.Debugf("Container locked. Can't run SendToRancherHandler. Event: [%s], ID: [%s]", event.Status, event.ID)
 		return nil
 	}
 	defer lock.Unlock()

--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -79,7 +79,7 @@ func (h *StartHandler) Handle(event *docker.APIEvents) error {
 	// Note: event.ID == container's ID
 	lock := locks.Lock("start." + event.ID)
 	if lock == nil {
-		log.Infof("Container locked. Can't run StartHandler. ID: [%s]", event.ID)
+		log.Debugf("Container locked. Can't run StartHandler. ID: [%s]", event.ID)
 		return nil
 	}
 	defer lock.Unlock()


### PR DESCRIPTION
I often see people reference this log statement in issues, thinking it is indicative of a problem, but it isn't.