### PR TITLE
Set cAdvisor to new image.

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -31,7 +31,16 @@ docker run \
   --publish=8080:8080 \
   --detach=true \
   --name=cadvisor \
-  google/cadvisor:v0.21.0 --logtostderr
+  google/cadvisor:latest --logtostderr
+
+
+echo "Waiting for cadvisor to come online"
+while true; do
+  if /usr/bin/curl -f -s http://localhost:8080/api >/dev/null 2>&1; then
+    break
+  fi
+  sleep .1
+done
 
 go test ./...
 

--- a/stats/integration_test.go
+++ b/stats/integration_test.go
@@ -34,7 +34,7 @@ func TestContainerStats(t *testing.T) {
 	createContainerOptions := client.CreateContainerOptions{
 		Name: "cadvisortest",
 		Config: &client.Config{
-			Image: "google/cadvisor:v0.21.0",
+			Image: "google/cadvisor:latest",
 		},
 	}
 


### PR DESCRIPTION
Also, wait for cAdvisor to be available on localhost:8080

Found that the tests were failing because cadvisor had not come up and started listening on port 8080.