### PR TITLE
Removed service name space from search domain

### DIFF
--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -38,11 +38,8 @@ func getDnsSearch(container *docker.Container) []string {
 	if container.Config.Labels != nil {
 		if value, ok := container.Config.Labels["io.rancher.stack_service.name"]; ok {
 			splitted := strings.Split(value, "/")
-			svc := strings.ToLower(splitted[1])
 			stack := strings.ToLower(splitted[0])
-			svcNameSpace = svc + "." + stack + "." + RancherDomain
 			stackNameSpace = stack + "." + RancherDomain
-			defaultDomains = append(defaultDomains, svcNameSpace)
 			defaultDomains = append(defaultDomains, stackNameSpace)
 		}
 	}


### PR DESCRIPTION
As we don't need it any more  - containers resolution is global


https://github.com/rancher/rancher/issues/4004