### PR TITLE
Revert "Removed service name space from search domain"

### DIFF
--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -38,8 +38,11 @@ func getDnsSearch(container *docker.Container) []string {
 	if container.Config.Labels != nil {
 		if value, ok := container.Config.Labels["io.rancher.stack_service.name"]; ok {
 			splitted := strings.Split(value, "/")
+			svc := strings.ToLower(splitted[1])
 			stack := strings.ToLower(splitted[0])
+			svcNameSpace = svc + "." + stack + "." + RancherDomain
 			stackNameSpace = stack + "." + RancherDomain
+			defaultDomains = append(defaultDomains, svcNameSpace)
 			defaultDomains = append(defaultDomains, stackNameSpace)
 		}
 	}


### PR DESCRIPTION
This reverts commit edff70c6e5ab287618a13b25e34039b9e26983a3.

We need service namespace for sidekick resolutions