### PR TITLE
Dynamically try and set MTU

### DIFF
--- a/events/entry.go
+++ b/events/entry.go
@@ -77,9 +77,9 @@ func getHandlersFn(dockerClient *docker.Client, rancherClient *rclient.RancherCl
 	handlers := map[string][]Handler{}
 
 	// Start Handler
-	startHandler := &StartHandler{
-		Client:            dockerClient,
-		ContainerStateDir: getContainerStateDir(),
+	startHandler, err := InitStartHandler(dockerClient, getContainerStateDir())
+	if err != nil {
+		return handlers, err
 	}
 	handlers["start"] = []Handler{startHandler}
 

--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -23,10 +24,23 @@ const RancherIPEnvKey = "RANCHER_IP="
 const RancherNameserver = "169.254.169.250"
 const RancherDomain = "rancher.internal"
 const RancherDns = "io.rancher.container.dns"
+const DockerBridgeInterface = "docker0"
+
+var (
+	systemContainerMtuSize = 1500
+	userContainerMtuSize   = 1500
+)
 
 type StartHandler struct {
 	Client            SimpleDockerClient
 	ContainerStateDir string
+}
+
+func InitStartHandler(client SimpleDockerClient, stateDir string) (*StartHandler, error) {
+	return &StartHandler{
+		Client:            client,
+		ContainerStateDir: stateDir,
+	}, setMtuSizes()
 }
 
 func getDnsSearch(container *docker.Container) []string {
@@ -153,8 +167,10 @@ func (h *StartHandler) Handle(event *docker.APIEvents) error {
 	}
 
 	pid := c.State.Pid
+
+	ipConfigCommand := getIPConfigCommand(isSystemContainer(c))
 	log.Infof("Assigning IP [%s], ContainerId [%s], Pid [%v]", rancherIP, event.ID, pid)
-	if err := configureIP(strconv.Itoa(pid), rancherIP); err != nil {
+	if err := configureIP(strconv.Itoa(pid), rancherIP, ipConfigCommand); err != nil {
 		// If it stopped running, don't return error
 		c, inspectErr := h.Client.InspectContainer(event.ID)
 		if inspectErr != nil {
@@ -175,6 +191,13 @@ func (h *StartHandler) Handle(event *docker.APIEvents) error {
 	}
 
 	return setupResolvConf(c)
+}
+
+var getIPConfigCommand = func(system bool) ipConfigCommand {
+	if system {
+		return &systemIPConfigCommand{}
+	}
+	return &userIPConfigCommand{}
 }
 
 func (h *StartHandler) getRancherIP(c *docker.Container) (string, error) {
@@ -217,8 +240,8 @@ func (h *StartHandler) getRancherIP(c *docker.Container) (string, error) {
 	return "", nil
 }
 
-func configureIP(pid string, ip string) error {
-	command := buildCommand(pid, ip)
+func configureIP(pid, ip string, cmd ipConfigCommand) error {
+	command := cmd.buildCommand(pid, ip)
 
 	output, err := command.CombinedOutput()
 	log.Debugf(string(output))
@@ -229,9 +252,91 @@ func configureIP(pid string, ip string) error {
 	return nil
 }
 
-var buildCommand = func(pid string, ip string) *exec.Cmd {
-	return exec.Command("net-util.sh", "-p", pid, "-i", ip)
+func isSystemContainer(c *docker.Container) bool {
+	if c.Config != nil {
+		if _, ok := c.Config.Labels[RancherSystemLabelKey]; ok {
+			return true
+		}
+	}
+	return false
 }
+
+func setMtuSizes() error {
+	gw, err := getDefaultGWDevice()
+	if err != nil {
+		return err
+	}
+	log.Debugf("DefaultGW: %s", gw)
+
+	interfaces, err := getInterfacesMap()
+	if err != nil {
+		return err
+	}
+
+	if iface, ok := interfaces[gw]; ok {
+		systemContainerMtuSize = iface.MTU
+
+		log.Debugf("GW MTU: %d", iface.MTU)
+		if dockerBridge, ok := interfaces[DockerBridgeInterface]; ok {
+			log.Debugf("DB MTU: %d", dockerBridge.MTU)
+			if dockerBridge.MTU < systemContainerMtuSize {
+				systemContainerMtuSize = dockerBridge.MTU
+			}
+		}
+	}
+	log.Debugf("system MTU set to: %d", systemContainerMtuSize)
+
+	// user MTU = system MTU - (Network COntainer headers(IP(20)+IPSec(58)) + UserContainer IP headers (20))
+	// MTU = System MTU - 98
+	userContainerMtuSize = systemContainerMtuSize - 98
+	log.Debugf("User MTU set to: %d", userContainerMtuSize)
+
+	return nil
+}
+
+func getInterfacesMap() (map[string]net.Interface, error) {
+	ifaceMap := map[string]net.Interface{}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return ifaceMap, err
+	}
+
+	for _, iface := range interfaces {
+		ifaceMap[iface.Name] = iface
+	}
+	return ifaceMap, nil
+}
+
+func (sc *systemIPConfigCommand) buildCommand(pid string, ip string) *exec.Cmd {
+	log.Debugf("systemMTU: %s", systemContainerMtuSize)
+	return exec.Command("net-util.sh", "-p", pid, "-i", ip, "-m", strconv.Itoa(systemContainerMtuSize))
+}
+
+func (uc *userIPConfigCommand) buildCommand(pid string, ip string) *exec.Cmd {
+	log.Debugf("UserMTU: %s", userContainerMtuSize)
+	return exec.Command("net-util.sh", "-p", pid, "-i", ip, "-m", strconv.Itoa(userContainerMtuSize))
+}
+
+func getDefaultGWDevice() (string, error) {
+	cmd := exec.Command("ip", "route", "show", "default", "0.0.0.0/0")
+
+	output, err := cmd.CombinedOutput()
+	log.Debugf(string(output))
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Split(string(output), " ")[4], nil
+}
+
+type ipConfigCommand interface {
+	buildCommand(string, string) *exec.Cmd
+}
+
+type systemIPConfigCommand struct{}
+
+type userIPConfigCommand struct{}
 
 type subnet struct {
 	CidrSize int

--- a/events/utils_test.go
+++ b/events/utils_test.go
@@ -7,8 +7,23 @@ import (
 	"testing"
 )
 
+type envIPConfigCommand struct{}
+
 func useEnvVars() bool {
 	return os.Getenv("CATTLE_DOCKER_USE_BOOT2DOCKER") == "true"
+}
+
+func (eIPC *envIPConfigCommand) buildCommand(pid string, ip string) *exec.Cmd {
+	// Assumes boot2docker. Also assumes that:
+	// - nsenter and net-utils.sh are on the path in the b2d vm
+	// - This link exists: ln -s /proc/ /host/proc
+	// See the README.md in this directory for setup details.
+	dockerMachine := os.Getenv("CATTLE_TEST_DOCKER_MACHINE_HOST")
+	if dockerMachine != "" {
+		return exec.Command("docker-machine", "ssh", dockerMachine, "sudo net-util.sh -p "+pid+" -i "+ip)
+	} else {
+		return exec.Command("boot2docker", "ssh", "-t", "sudo", "net-util.sh", "-p", pid, "-i", ip)
+	}
 }
 
 func createContainer(client *docker.Client) (*docker.Container, error) {
@@ -100,17 +115,8 @@ func prep(t *testing.T) *docker.Client {
 	}
 
 	if useEnvVars() {
-		buildCommand = func(pid string, ip string) *exec.Cmd {
-			// Assumes boot2docker. Also assumes that:
-			// - nsenter and net-utils.sh are on the path in the b2d vm
-			// - This link exists: ln -s /proc/ /host/proc
-			// See the README.md in this directory for setup details.
-			dockerMachine := os.Getenv("CATTLE_TEST_DOCKER_MACHINE_HOST")
-			if dockerMachine != "" {
-				return exec.Command("docker-machine", "ssh", dockerMachine, "sudo net-util.sh -p "+pid+" -i "+ip)
-			} else {
-				return exec.Command("boot2docker", "ssh", "-t", "sudo", "net-util.sh", "-p", pid, "-i", ip)
-			}
+		getIPConfigCommand = func(system bool) ipConfigCommand {
+			return &envIPConfigCommand{}
 		}
 	}
 

--- a/scripts/lib/net-util.sh
+++ b/scripts/lib/net-util.sh
@@ -22,6 +22,7 @@ wait_for_dev()
 
 IP=
 PID=
+MTU=
 DEV=eth0
 ARGS="$@"
 
@@ -38,6 +39,10 @@ while [ "$#" -gt 0 ]; do
     -d)
         shift 1
         DEV=$1
+        ;;
+    -m)
+        shift 1
+        MTU=$1
         ;;
     esac
     shift 1
@@ -77,6 +82,12 @@ if [ -n "$IP" ]; then
     if ! ip addr show dev $DEV  | grep '[[:space:]]*inet' | awk '{ print $2 }' | grep -q $IP; then
         echo "Adding $IP to $DEV"
         ip addr add dev $DEV $IP
+
+        if [ -n "$MTU" ]; then
+            echo "seting $DEV mtu to: $MTU"
+            ip link set dev $DEV mtu $MTU
+        fi
+
         ip link show
         ip addr show
     fi


### PR DESCRIPTION
We are not accounting for IPSec tunnel or IP headers from our network container in our container MTU sizes. This causes UDP performance to plummet. 

This PR looks at the default gateways interface. 