### PR TITLE
Add rancher search domain before host domains

### DIFF
--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -48,6 +48,9 @@ func getDnsSearch(container *docker.Container) []string {
 		}
 	}
 
+	// default rancher domain
+	defaultDomains = append(defaultDomains, RancherDomain)
+
 	//from search domains
 	if container.HostConfig.DNSSearch != nil {
 		for _, domain := range container.HostConfig.DNSSearch {
@@ -57,8 +60,6 @@ func getDnsSearch(container *docker.Container) []string {
 		}
 	}
 
-	// default rancher domain
-	defaultDomains = append(defaultDomains, RancherDomain)
 	return defaultDomains
 }
 


### PR DESCRIPTION
This PR changes the order of the search domain passed to each container's `resolv.conf`. Essentially, we believe that `rancher.internal` should be searched before any host search domains.

Here's the use case we hit upon:
1. Assume that the host machine has the search domain: "search foobar.com"
2. Assume that a wildcard domain (*.foobar.com) exists and points to "biz.foobar.com"
3. Launch a new service in rancher, then execute a shell on it and type: "ping rancher-metadata"

The above would resolve to "biz.foobar.com" which is not what was intended.
